### PR TITLE
[FEAT] : Note UPDATE Editor functionality added  

### DIFF
--- a/src/components/EditorModal/EditorModal.jsx
+++ b/src/components/EditorModal/EditorModal.jsx
@@ -1,0 +1,111 @@
+import React, { useState } from "react";
+import "../CreateNote/create-note.css";
+import "./editorModal.css";
+import { Editor } from "../Editor/Editor";
+import { BsFillPinFill, BsPin } from "react-icons/bs";
+import { useNotes } from "../../context/notes-context";
+import Colorpalette from "../color/Colorpalette";
+import { Label } from "../Label/Label";
+
+export const EditorModal = ({ id, currentNote, showModal }) => {
+  
+  const { updateNote } = useNotes();
+  const [updateNoted, setUpdateNoted] = useState(currentNote);
+
+  const handleInput = (e) => {
+    setUpdateNoted({ ...updateNoted, description: e });
+  };
+
+  return (
+    <div className="modal">
+      <form
+        className={`create-note ${updateNoted.color}`}
+        onSubmit={(e) => {
+          e.preventDefault();
+          updateNote(updateNoted, id);
+          showModal(false);
+        }}
+      >
+        <div className="flex-row note-title-pin spc-btwn ">
+          <input
+            className="note-title-input"
+            value={updateNoted.title}
+            onChange={(e) => {
+              setUpdateNoted({ ...updateNoted, title: e.target.value });
+            }}
+          />
+
+          <button
+            className="note-pin"
+            type="button"
+            onClick={() => {
+              setUpdateNoted({ ...updateNoted, ispin: !updateNoted.ispin });
+            }}
+          >
+            {updateNoted.ispin ? <BsFillPinFill /> : <BsPin />}
+          </button>
+        </div>
+        <div>
+          {/* REACT QUILL EDITOR */}
+          <Editor
+            handleInput={handleInput}
+            description={updateNoted.description}
+          />
+
+          <div className="flex-row gap-btwn">
+            {updateNoted.labels.map((label) => {
+              return (
+                <div key={label} className="flex-row label-wrap">
+                  <p>{label}</p>
+                  <span
+                    className="label-delete"
+                    onClick={() => {
+                      setUpdateNoted({
+                        ...updateNoted,
+                        labels: updateNoted.labels.filter(
+                          (curr) => curr !== label
+                        ),
+                      });
+                    }}
+                  >
+                    x
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+          <nav className="flex-row note-options">
+            {/* LABEL */}
+            <Label
+              labels={updateNoted.labels}
+              addLabels={(label) => {
+                setUpdateNoted({
+                  ...updateNoted,
+                  labels: [...updateNoted.labels, label],
+                });
+              }}
+            />
+
+            {/* COLOR PALETTE */}
+            <Colorpalette
+              updateColor={(color) => {
+                setUpdateNoted({ ...updateNoted, color: color });
+              }}
+            />
+            <button type="submit" className="btn add-btn">
+              Edit
+            </button>
+            <button
+              className="btn secondary-btn add-btn close-btn"
+              onClick={() => {
+                showModal(false);
+              }}
+            >
+              Close
+            </button>
+          </nav>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/components/EditorModal/EditorModal.jsx
+++ b/src/components/EditorModal/EditorModal.jsx
@@ -12,6 +12,7 @@ export const EditorModal = ({ id, currentNote, showModal }) => {
   const { updateNote } = useNotes();
   const [updateNoted, setUpdateNoted] = useState(currentNote);
 
+  
   const handleInput = (e) => {
     setUpdateNoted({ ...updateNoted, description: e });
   };

--- a/src/components/EditorModal/EditorModal.jsx
+++ b/src/components/EditorModal/EditorModal.jsx
@@ -81,7 +81,7 @@ export const EditorModal = ({ id, currentNote, showModal }) => {
               addLabels={(label) => {
                 setUpdateNoted({
                   ...updateNoted,
-                  labels: [...updateNoted.labels, label],
+                  labels:updateNoted.labels.includes(label)?updateNoted.labels:[...updateNoted.labels, label],
                 });
               }}
             />

--- a/src/components/EditorModal/editorModal.css
+++ b/src/components/EditorModal/editorModal.css
@@ -1,0 +1,11 @@
+.modal{
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    width: 100vw;
+    height: 100%;
+    position: fixed;
+    background-color: rgba(0, 0, 0, 0.4);
+    z-index:2
+}

--- a/src/components/Note/Note.jsx
+++ b/src/components/Note/Note.jsx
@@ -1,15 +1,7 @@
 import React from "react";
 import "./note.css";
-import { useNotes } from "../../context/notes-context";
-import { FiTrash2 } from "react-icons/fi";
-import { RiInboxArchiveLine, RiInboxUnarchiveLine } from "react-icons/ri";
-import { BsFillPinFill, BsPin } from "react-icons/bs";
-import { MdRestoreFromTrash, MdDeleteForever } from "react-icons/md";
 import Masonry from "react-masonry-css";
-import Colorpalette from "../color/Colorpalette";
-import { useArchive } from "../../context/archive-context";
-import { matchPath, useLocation } from "react-router-dom";
-import { Label } from "../Label/Label";
+import { NoteCard } from "../NoteCard/NoteCard";
 
 const breakpointColumnsObj = {
   default: 4,
@@ -19,11 +11,7 @@ const breakpointColumnsObj = {
 };
 
 export const Note = ({ arr, heading }) => {
-  const { togglePin, Change_color, inTrash, removeFromnote, tagUpdate } =
-    useNotes();
-  const { addToArchive, restoreToArchive, deleteToArchive } = useArchive();
-  const { pathname } = useLocation();
-
+  
   return (
     <div className="note-collection">
       {arr.length !== 0 && heading}
@@ -32,98 +20,9 @@ export const Note = ({ arr, heading }) => {
         className="my-masonry-grid"
         columnClassName="my-masonry-grid_column"
       >
-        {arr.map(({ _id, Note }) => {
-          return (
-            <div className={`note ${Note.color}`} key={_id}>
-              <div className="flex-row spc-btwn">
-                <div>{Note.title}</div>
-                <button
-                  className="note-pin"
-                  type="button"
-                  onClick={() => {
-                    togglePin(Note, _id);
-                  }}
-                >
-                  {(pathname === "/notes" || matchPath("/labels/*", pathname)) &&
-                    (Note.ispin ? <BsFillPinFill /> : <BsPin />)}
-                </button>
-              </div>
-
-              <div
-                className="note-descr"
-                dangerouslySetInnerHTML={{
-                  __html: Note.description,
-                }}
-              />
-              <div className="flex-row gap-btwn">
-                {Note.labels.map((label) => {
-                  return (
-                    <div key={label} className="flex-row label-wrap">
-                      <p>{label}</p>
-                      <span
-                        className="label-delete"
-                        onClick={() => tagUpdate(Note, _id, label)}
-                      >
-                        x
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-              <div className="flex-row note-options-set">
-                {(pathname === "/notes" || matchPath("/labels/*", pathname)) && (
-                  <Label
-                    labels={Note.labels}
-                    addLabels={(tag) => {
-                      tagUpdate(Note, _id, tag);
-                    }}
-                  />
-                )}
-
-                {(pathname === "/notes" || matchPath("/labels/*", pathname)) && (
-                  <Colorpalette
-                    updateColor={(color) => Change_color(Note, _id, color)}
-                  />
-                )}
-                {(pathname === "/notes" || matchPath("/labels/*", pathname)) && (
-                  <RiInboxArchiveLine
-                    onClick={() => {
-                      addToArchive(Note, _id);
-                    }}
-                  />
-                )}
-
-                {(pathname === "/notes" || matchPath("/labels/*", pathname)) && (
-                  <FiTrash2
-                    onClick={() => {
-                      inTrash(Note, _id);
-                    }}
-                  />
-                )}
-                {pathname === "/archives" && (
-                  <RiInboxUnarchiveLine
-                    onClick={() => {
-                      restoreToArchive(_id);
-                    }}
-                  />
-                )}
-                {pathname === "/archives" && (
-                  <MdDeleteForever onClick={() => deleteToArchive(_id)} />
-                )}
-                {pathname === "/trash" && (
-                  <MdRestoreFromTrash
-                    onClick={() => {
-                      inTrash(Note, _id);
-                    }}
-                  />
-                )}
-                {pathname === "/trash" && (
-                  <MdDeleteForever onClick={() => removeFromnote(_id)} />
-                )}
-              </div>
-            </div>
-          );
-        })}
+        {arr.map(({ _id, Note }) => 
+              <NoteCard key ={_id} Note={Note} id={_id} />
+              )}
       </Masonry>
     </div>
   );

--- a/src/components/NoteCard/NoteCard.jsx
+++ b/src/components/NoteCard/NoteCard.jsx
@@ -1,0 +1,124 @@
+import React, { useState } from "react";
+import { useNotes } from "../../context/notes-context";
+import { FiTrash2 } from "react-icons/fi";
+import { RiInboxArchiveLine, RiInboxUnarchiveLine } from "react-icons/ri";
+import { BsFillPinFill, BsPin } from "react-icons/bs";
+import {
+  MdRestoreFromTrash,
+  MdDeleteForever,
+  MdOutlineEdit,
+} from "react-icons/md";
+import Colorpalette from "../color/Colorpalette";
+import { useArchive } from "../../context/archive-context";
+import { matchPath, useLocation } from "react-router-dom";
+import { Label } from "../Label/Label";
+import { EditorModal } from "../EditorModal/EditorModal";
+
+export const NoteCard = ({ Note, id }) => {
+  const { togglePin, Change_color, inTrash, removeFromnote, tagUpdate } =
+    useNotes();
+  const { addToArchive, restoreToArchive, deleteToArchive } = useArchive();
+  const { pathname } = useLocation();
+  const [modal, showModal] = useState(false);
+
+  return (
+    <div className={`note ${Note.color}`} key={id}>
+      {modal && (
+        <EditorModal id={id} currentNote={Note} showModal={showModal} />
+      )}
+      <div className="flex-row spc-btwn">
+        <div>{Note.title}</div>
+        <button
+          className="note-pin"
+          type="button"
+          onClick={() => {
+            togglePin(Note, id);
+          }}
+        >
+          {(pathname === "/notes" || matchPath("/labels/*", pathname)) &&
+            (Note.ispin ? <BsFillPinFill /> : <BsPin />)}
+        </button>
+      </div>
+
+      <div
+        className="note-descr"
+        dangerouslySetInnerHTML={{
+          __html: Note.description,
+        }}
+      />
+      <div className="flex-row gap-btwn">
+        {Note.labels.map((label) => {
+          return (
+            <div key={label} className="flex-row label-wrap">
+              <p>{label}</p>
+              <span
+                className="label-delete"
+                onClick={() => tagUpdate(Note, id, label)}
+              >
+                x
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      <div className="flex-row note-options-set">
+        {(pathname === "/notes" || matchPath("/labels/*", pathname)) && (
+          <Label
+            labels={Note.labels}
+            addLabels={(tag) => {
+              tagUpdate(Note, id, tag);
+            }}
+          />
+        )}
+
+        {(pathname === "/notes" || matchPath("/labels/*", pathname)) && (
+          <Colorpalette
+            updateColor={(color) => Change_color(Note, id, color)}
+          />
+        )}
+        {(pathname === "/notes" || matchPath("/labels/*", pathname)) && (
+          <RiInboxArchiveLine
+            onClick={() => {
+              addToArchive(Note, id);
+            }}
+          />
+        )}
+
+        {(pathname === "/notes" || matchPath("/labels/*", pathname)) && (
+          <FiTrash2
+            onClick={() => {
+              inTrash(Note, id);
+            }}
+          />
+        )}
+        {pathname === "/archives" && (
+          <RiInboxUnarchiveLine
+            onClick={() => {
+              restoreToArchive(id);
+            }}
+          />
+        )}
+        {pathname === "/archives" && (
+          <MdDeleteForever onClick={() => deleteToArchive(id)} />
+        )}
+        {pathname === "/trash" && (
+          <MdRestoreFromTrash
+            onClick={() => {
+              inTrash(Note, id);
+            }}
+          />
+        )}
+        {pathname === "/trash" && (
+          <MdDeleteForever onClick={() => removeFromnote(id)} />
+        )}
+        {pathname !== "/trash" && (
+          <MdOutlineEdit
+            onClick={() => {
+              showModal(true);
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
Can open an editor on an already created note by 
clicking the edit icon
pops up an editor for note updation

![recording](https://netlify-cocoon.netlify.app/.netlify/functions/fetch?code=307&path=eyJzaXRlX2lkIjoiZmM2NTEzNmEtOTAwZi00YmU4LWJiODAtNWQ2NzFlMWJmMjhmIiwiZGVwbG95X2lkIjoiNjI0Y2I4MDRmN2Q0ZTUwMDA5ZmM4ODFmIiwiaWQiOiI2MTdjOWZlOS1jNjM5LTQyNWMtOTk3NS0xOTgyMzFjYzkwOTEifQ==)


<details><summary>Browser metadata</summary>





```
Path:      /notes
Browser:   Chrome 99.0.4844.84 on Windows 10
Viewport:  1536 x 775 @1.25x
Language:  en-US
Cookies:   Enabled
```

[Open in BrowserStack](https://www.browserstack.com/user/try-live?url=https%3A%2F%2Fdeploy-preview-11--monkeep.netlify.app%2Fnotes&os=Windows&os_version=10&browser=Chrome&browser_version=99.0&resolution=1536x775&speed=1&start=true&ref=netlify-source)



</details>

[Open Deploy Preview](https://deploy-preview-11--monkeep.netlify.app/notes) · [Mark as Resolved](https://app.netlify.com/cdp/resolve?deployID=624cb804f7d4e50009fc881f&commentID=624cbac443622719c74ec8f9&resolution=resolved)